### PR TITLE
fix(QTree): incorrect type for tickStrategy on QTreeNode

### DIFF
--- a/ui/types/api/qtree.d.ts
+++ b/ui/types/api/qtree.d.ts
@@ -105,7 +105,7 @@ export type QTreeNode<TExtra = unknown> = Omit<
     handler?: (node: QTreeNode<TExtra>) => void;
     tickable?: boolean;
     noTick?: boolean;
-    tickStrategy?: "leaf" | "leaf-filtered" | "string" | "none";
+    tickStrategy?: "leaf" | "leaf-filtered" | "strict" | "none";
     lazy?: boolean;
     header?: string;
     body?: string;


### PR DESCRIPTION
The supported types are `none`, `strict`, `leaf` and `leaf-filtered`.

Type `string` here is most likely a mistake and should have been `strict`, just like how the component prop `tick-strategy` is.

<!--
  Please make sure to read the Pull Request Guidelines:
  https://github.com/quasarframework/quasar/blob/dev/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on an Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to [start a new feature discussion](https://github.com/quasarframework/quasar/discussions/new?category=ideas-proposals) first and wait for approval before working on it)

**Other information:**
